### PR TITLE
Dockerized app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM meteorhacks/meteord:devbuild
+
+# Uncomment for production
+# FROM meteorhacks/meteord:onbuild
+MAINTAINER Ricardo Roman <r.rmn92@gmail.com>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# You can read the Docker Compose documentation at:
+#
+#   https://docs.docker.com/compose/
+#
+# Run with file with `docker-compose up -d`.
+#
+# We use two separate Docker containers: one for the database and one for the
+# Misas application.
+#
+
+# Uncomment for production
+
+misasdb:
+  image: mongo
+  # volumes:
+  #   - ./data/runtime/db:/data/db
+  #   - ./data/dump:/dump
+  command: mongod --smallfiles --oplogSize 128
+  ports:
+    - 27017
+
+misas:
+  build: .
+  links:
+    - misasdb
+  environment:
+    - MONGO_URL=mongodb://misasdb/misas
+    - ROOT_URL=http://localhost:80
+  ports:
+    - 80:80


### PR DESCRIPTION
Please review this feature to dockerize the application. It has been tested.
To run, please install docker and then run `docker-compose up`. This does not persist data.

For production purposes, uncomment the necessary lines in `Dockerfile` and `docker-compose.yml`. This will persist data and redownload meteor and packages upon build.
