### PR TITLE
fixed by 1 mistake

### DIFF
--- a/app/client/parroquias/directives/parroquias.search.js
+++ b/app/client/parroquias/directives/parroquias.search.js
@@ -10,7 +10,7 @@ angular.module('parroquias').directive('parroquiasSearch', function() {
       $reactive(this).attach($scope);
       pssc = this;
       pssc.pageInfo = {
-        page: 0,
+        page: 1,
         perPage: 20
       };
       pssc.changePage = function(newPage){
@@ -28,7 +28,7 @@ angular.module('parroquias').directive('parroquiasSearch', function() {
       pssc.subscribe('parroquias.search', function() {
         return [
           {
-            skip: parseInt(pssc.getReactively('pageInfo.page')*pssc.getReactively('pageInfo.perPage')),
+            skip: parseInt((pssc.getReactively('pageInfo.page')-1)*pssc.getReactively('pageInfo.perPage')),
             limit: parseInt(pssc.getReactively('pageInfo.perPage'))
           }, 
           pssc.getReactively('searchText')


### PR DESCRIPTION
I accidentally assumed the pagination directive was zero based and therefore the last page on every paginated result was not shown. Here is the fix for that. By the way it's pretty cool that we don't have down time. I think since this was already approved I should just test the pull request for this, so I am just going to pull this.
